### PR TITLE
Improve readability on docs index and key guides

### DIFF
--- a/docs/features/more-features.md
+++ b/docs/features/more-features.md
@@ -5,23 +5,23 @@ sidebar_label: Additional Features
 
 # Additional Features
 
-This page describes additional features in Kilo Code that enhance your development workflow.
+Kilo Code's extras streamline routine tasks and improve accessibility.
 
 ## Suggested Responses
 
-Kilo Code provides suggested responses to questions, saving you time typing. These suggestions appear as buttons below the chat input box after you ask a question. Click a suggestion to quickly use it as your next prompt.
-
-This feature aims to streamline your workflow by anticipating your potential follow-up questions and providing one-click access to relevant prompts.
+Kilo Code offers suggested responses so you spend less time typing.
+- After you ask a question, buttons appear below the chat box.
+- Click a button to reuse it as your next prompt.
 
 ## Text to Speech
 
-Kilo Code includes a Text-to-Speech (TTS) feature that reads out the AI responses, allowing you to listen to the information instead of reading it. This can be helpful for accessibility, learning, or simply for a change of pace.
-
-To use Text-to-Speech, simply enable it in the Kilo Code settings. Once enabled, a speaker icon will appear next to each AI response in the chat. Click the icon to start listening.
+The Text-to-Speech feature lets Kilo Code read responses aloud.
+1. Enable TTS in settings.
+2. Click the speaker icon next to any response to start listening.
 
 ## Global Language Support
 
-Kilo Code supports 14 languages, making it accessible to a wider range of users globally. You can now use Kilo Code in:
+Kilo Code supports 14 languages:
 
 - Simplified Chinese
 - Traditional Chinese
@@ -38,6 +38,4 @@ Kilo Code supports 14 languages, making it accessible to a wider range of users 
 - Polish
 - Catalan
 
-To change your language, go to **Advanced Settings > Language** in the Kilo Code settings panel.
-
-This global update ensures a smoother and more inclusive coding experience for users around the world.
+Change languages under **Advanced Settings > Language**.

--- a/docs/getting-started/your-first-task.md
+++ b/docs/getting-started/your-first-task.md
@@ -4,7 +4,9 @@ sidebar_label: Your First Task
 
 # Starting Your First Task with Kilo Code
 
-Now that you've [set up Kilo Code](/getting-started/setting-up), you're ready to start using Kilo Code! This guide walks you through your first interaction.
+This quick tour shows how Kilo Code handles a simple request from start to finish.
+
+After you [set up Kilo Code](/getting-started/setting-up), follow these steps:
 
 ## Step 1: Open the Kilo Code Panel
 
@@ -44,8 +46,8 @@ Kilo Code analyzes your request and proposes specific actions. These may include
 <img src="/docs/img/your-first-task/your-first-task-7.png" alt="Reviewing a proposed file creation action" width="400" />
 *Kilo Code shows exactly what action it wants to perform and waits for your approval.*
 
-* In **Code** mode, many capabilities required to write code are enabled by default. 
-* In **Architect** and **Ask** modes, the agent will not write any code. 
+* In **Code** mode, writing capabilities are on by default.
+* In **Architect** and **Ask** modes, Kilo Code won't write code.
 
 :::tip
 
@@ -64,10 +66,10 @@ Kilo Code works iteratively. After each action, it waits for your feedback befor
 
 ## Conclusion
 
-You've now completed your first task with Kilo Code! Through this process, you've learned:
+You've completed your first task. Along the way you learned:
 
 * How to interact with Kilo Code using natural language
-* The approval-based workflow that keeps you in control
-* The iterative approach Kilo Code uses to solve problems step-by-step
+* Why approval keeps you in control
+* How iteration lets the AI refine its work
 
-This iterative, approval-based workflow is at the core of how Kilo Code works—letting AI handle the tedious parts of coding while you maintain complete oversight. Now that you understand the basics, you're ready to tackle more complex tasks, explore different [modes](/basic-usage/using-modes) for specialized workflows, or try the [auto-approval feature](/features/auto-approving-actions) to speed up repetitive tasks.
+Ready for more? Explore different [modes](/basic-usage/using-modes) or try [auto-approval](/features/auto-approving-actions) to speed up repetitive tasks.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -7,7 +7,7 @@ import Image from '@site/src/components/Image';
 
 # Kilo Code Documentation
 
-Kilo Code is an open source AI agent VS Code extension. It helps you write code more efficiently by generating code, automating tasks, and providing suggestions.
+Kilo Code **accelerates** development with AI-driven code generation and task automation. This open source extension plugs directly into VS Code.
 
 ## What Can Kilo Code Do?
 
@@ -30,7 +30,11 @@ Kilo Code is an open source AI agent VS Code extension. It helps you write code 
 
 ### Basics
 
-You interact with Kilo Code through [the chat interface](/basic-usage/the-chat-interface) - just type what you want and Kilo Code will use the latest coding-optomized AI models to fulfill the request. You can change [modes](/basic-usage/using-modes) to have Kilo Code act in different ways, control what [actions](/features/auto-approving-actions) Kilo code can take, and interact with your code directly with [code actions](/features/code-actions).
+Use [the chat interface](/basic-usage/the-chat-interface) to tell Kilo Code what you need. It relies on coding‑optimized AI models to complete each request.
+
+- Switch [modes](/basic-usage/using-modes) to fit the task
+- Control allowed [actions](/features/auto-approving-actions)
+- Run direct [code actions](/features/code-actions)
 
 ### Using Kilo Code
 


### PR DESCRIPTION
## Summary
- rework intro on home page
- shorten and bullet key points in *Additional Features*
- streamline first task walkthrough

## Testing
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6883874aa350832e93b8ff59c6c2cf61