### PR TITLE
add docs for fireworks

### DIFF
--- a/docs/providers/fireworks.md
+++ b/docs/providers/fireworks.md
@@ -1,0 +1,47 @@
+---
+sidebar_label: Fireworks AI
+---
+
+# Using Fireworks AI With Kilo Code
+
+Fireworks AI is a high-performance platform for running AI models that offers fast access to a wide range of open-source and proprietary language models. Built for speed and reliability, Fireworks AI provides both serverless and dedicated deployment options with OpenAI-compatible APIs.
+
+**Website:** [https://fireworks.ai/](https://fireworks.ai/)
+
+---
+
+## Getting an API Key
+
+1. **Sign Up/Sign In:** Go to [Fireworks AI](https://fireworks.ai/) and create an account or sign in.
+2. **Navigate to API Keys:** After logging in, go to the [API Keys page](https://app.fireworks.ai/settings/users/api-keys) in the account settings.
+3. **Create a Key:** Click "Create API key" and give your key a descriptive name (e.g., "Kilo Code").
+4. **Copy the Key:** Copy the API key *immediately* and store it securely. You will not be able to see it again.
+
+---
+
+## Supported Models
+
+Kilo Code supports the following Fireworks AI models:
+
+* `accounts/fireworks/models/kimi-k2-instruct` - Kimi K2 instruction-tuned model
+* `accounts/fireworks/models/qwen3-235b-a22b-instruct-2507` - Qwen 3 235B instruction-tuned model  
+* `accounts/fireworks/models/qwen3-coder-480b-a35b-instruct` - Qwen 3 Coder 480B for code generation
+* `accounts/fireworks/models/deepseek-r1-0528` - DeepSeek R1 reasoning model
+* `accounts/fireworks/models/deepseek-v3` - DeepSeek V3 latest generation model
+
+---
+
+## Configuration in Kilo Code
+
+1. **Open Kilo Code Settings:** Click the gear icon (<Codicon name="gear" />) in the Kilo Code panel.
+2. **Select Provider:** Choose "Fireworks AI" from the "API Provider" dropdown.
+3. **Enter API Key:** Paste your Fireworks AI API key into the "Fireworks AI API Key" field.
+4. **Select Model:** Choose your desired model from the "Model" dropdown.
+
+---
+
+## Tips and Notes
+
+* **Performance:** Fireworks AI is optimized for speed and offers excellent performance for both chat and completion tasks.
+* **Pricing:** Refer to the [Fireworks AI Pricing](https://fireworks.ai/pricing) page for current pricing information.
+* **Rate Limits:** Fireworks AI has usage-based rate limits. Monitor your usage in the dashboard and consider upgrading your plan if needed.

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/providers/fireworks.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/providers/fireworks.md
@@ -1,0 +1,47 @@
+---
+sidebar_label: Fireworks AI
+---
+
+# 在 Kilo Code 中使用 Fireworks AI
+
+Fireworks AI 是一个高性能的 AI 模型运行平台，可以快速访问各种开源和专有语言模型。它专为速度和可靠性而构建，提供无服务器和专用部署选项，并兼容 OpenAI API。
+
+**网站：** [https://fireworks.ai/](https://fireworks.ai/)
+
+---
+
+## 获取 API 密钥
+
+1. **注册/登录：** 前往 [Fireworks AI](https://fireworks.ai/) 创建账户或登录。
+2. **导航到 API 密钥：** 登录后，在账户设置中进入 [API Keys 页面](https://app.fireworks.ai/settings/users/api-keys)。
+3. **创建密钥：** 点击 "Create API key" 并为您的密钥输入一个描述性名称（例如 "Kilo Code"）。
+4. **复制密钥：** *立即* 复制 API 密钥并安全存储。您将无法再次查看它。
+
+---
+
+## 支持的模型
+
+Kilo Code 支持以下 Fireworks AI 模型：
+
+* `accounts/fireworks/models/kimi-k2-instruct` - Kimi K2 指令调优模型
+* `accounts/fireworks/models/qwen3-235b-a22b-instruct-2507` - Qwen 3 235B 指令调优模型  
+* `accounts/fireworks/models/qwen3-coder-480b-a35b-instruct` - Qwen 3 Coder 480B 代码生成模型
+* `accounts/fireworks/models/deepseek-r1-0528` - DeepSeek R1 推理模型
+* `accounts/fireworks/models/deepseek-v3` - DeepSeek V3 最新一代模型
+
+---
+
+## 在 Kilo Code 中配置
+
+1. **打开 Kilo Code 设置：** 在 Kilo Code 面板中点击齿轮图标 (<Codicon name="gear" />)。
+2. **选择提供商：** 从 "API Provider" 下拉菜单中选择 "Fireworks AI"。
+3. **输入 API 密钥：** 将您的 Fireworks AI API 密钥粘贴到 "Fireworks AI API Key" 字段中。
+4. **选择模型：** 从 "Model" 下拉菜单中选择您想要的模型。
+
+---
+
+## 提示和注意事项
+
+* **性能：** Fireworks AI 针对速度进行了优化，在聊天和完成任务方面都提供出色的性能。
+* **定价：** 请参考 [Fireworks AI 定价](https://fireworks.ai/pricing) 页面了解当前定价信息。
+* **速率限制：** Fireworks AI 有基于使用量的速率限制。请在控制台中监控您的使用情况，如有需要请考虑升级您的计划。

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -52,6 +52,7 @@ const sidebars: SidebarsConfig = {
                 "providers/chutes-ai",
                 "providers/claude-code",
                 "providers/deepseek",
+                "providers/fireworks",
                 "providers/vertex",
                 "providers/glama",
                 "providers/gemini",


### PR DESCRIPTION
The PR https://github.com/Kilo-Org/kilocode/pull/1763 fixes the Fireworks provider in Kilo Code.

This PR adds documentation for Fireworks to maintain consistency.